### PR TITLE
fix(config): Added the watch task configuration back in

### DIFF
--- a/_config/task.sass.js
+++ b/_config/task.sass.js
@@ -41,6 +41,10 @@ function getTaskConfig(projectConfig) {
 				]
 			}
 		},
+		watch: [
+			projectConfig.paths.src.sass + '**/*.scss',
+			projectConfig.paths.src.components + '**/*.scss'
+		],
 		defaultConfig: {
 			autoprefixer: {
 				browsers: ['>5%']
@@ -51,11 +55,7 @@ function getTaskConfig(projectConfig) {
 			pxtorem: {
 				replace:   false,
 				rootValue: 16
-			},
-			watch: [
-				projectConfig.paths.src.sass + '**/*.scss',
-				projectConfig.paths.src.components + '**/*.scss'
-			]
+			}
 		}
 
 	};


### PR DESCRIPTION
## Description
Add the default configuration for the watch task back in to the project.

## Todos
> Make sure you’ve completed these:

- [x] Does this feature run on all supported platforms?
- [ ] Are there tests around this feature?
- [ ] Is there documentation for this feature?

The watch task configuration was moved to the default config object but the implementation never
 extended to cover that approach.