### PR TITLE
build(packagejson): Add the missing commitizen types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,8 @@
         "refactor",
         "perf",
         "test",
+        "build",
+        "ci",
         "chore",
         "revert"
       ],


### PR DESCRIPTION
The newer version of Commitizen allow the use of the build and ci flags for commits. This adds those to validate-commit-msg as types that can be used