### PR TITLE
feat: Add a .stylelintignore file to the module

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,1 @@
+#Add paths to be ignored by stylelint here

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -46,4 +46,9 @@ cartridgeUtil.addToRc()
 			copyPath: '.stylelintrc.log'
 		}]);
 	})
+	.then(() => {
+		return cartridgeUtil.copyToProjectDir([{
+			copyPath: '.stylelintignore'
+		}]);
+	})
 	.then(cartridgeUtil.finishInstall);


### PR DESCRIPTION
When installing cartridge sass will now include a stylelintignore file in the root of the project fixing #163 